### PR TITLE
chore: not sending to builder when it's unhealthy

### DIFF
--- a/crates/rollup-boost/src/cli.rs
+++ b/crates/rollup-boost/src/cli.rs
@@ -101,6 +101,11 @@ pub struct Args {
     #[arg(long, env, default_value = "false")]
     pub use_l2_client_for_state_root: bool,
 
+    /// Allow all engine API calls to builder even when marked as unhealthy
+    /// This is default true assuming no builder CL set up
+    #[arg(long, env, default_value = "true")]
+    pub allow_traffic_to_unhealthy_builder: bool,
+
     #[clap(flatten)]
     pub flashblocks: FlashblocksArgs,
 }
@@ -196,6 +201,7 @@ impl Args {
             self.block_selection_policy,
             probes.clone(),
             self.use_l2_client_for_state_root,
+            self.allow_traffic_to_unhealthy_builder,
         );
 
         let health_handle =

--- a/crates/rollup-boost/src/proxy.rs
+++ b/crates/rollup-boost/src/proxy.rs
@@ -533,6 +533,7 @@ mod tests {
         // Assert the builder received the correct payload
         let builder = &test_harness.builder;
         let builder_requests = builder.requests.lock().await;
+        println!("builder_requests: {:?}", builder_requests);
         let builder_req = builder_requests.first().unwrap();
         assert_eq!(builder_requests.len(), 1);
         assert_eq!(builder_req["method"], expected_method);

--- a/crates/rollup-boost/src/proxy.rs
+++ b/crates/rollup-boost/src/proxy.rs
@@ -215,10 +215,10 @@ mod tests {
             let middleware = tower::ServiceBuilder::new().layer(ProxyLayer::new(
                 format!("http://{}:{}", l2.addr.ip(), l2.addr.port()).parse::<Uri>()?,
                 JwtSecret::random(),
-                1,
+                5000,
                 format!("http://{}:{}", builder.addr.ip(), builder.addr.port()).parse::<Uri>()?,
                 JwtSecret::random(),
-                1,
+                5000,
             ));
 
             let temp_listener = TcpListener::bind("127.0.0.1:0").await?;
@@ -480,7 +480,7 @@ mod tests {
         .unwrap();
 
         let (probe_layer, _) = ProbeLayer::new();
-        let proxy_layer = ProxyLayer::new(l2_auth_uri.clone(), jwt, 1, l2_auth_uri, jwt, 1);
+        let proxy_layer = ProxyLayer::new(l2_auth_uri.clone(), jwt, 5000, l2_auth_uri, jwt, 5000);
 
         // Create a layered server
         let server = ServerBuilder::default()

--- a/crates/rollup-boost/src/proxy.rs
+++ b/crates/rollup-boost/src/proxy.rs
@@ -533,7 +533,6 @@ mod tests {
         // Assert the builder received the correct payload
         let builder = &test_harness.builder;
         let builder_requests = builder.requests.lock().await;
-        println!("builder_requests: {:?}", builder_requests);
         let builder_req = builder_requests.first().unwrap();
         assert_eq!(builder_requests.len(), 1);
         assert_eq!(builder_req["method"], expected_method);

--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -127,10 +127,11 @@ impl RollupBoostServer {
             .remove_by_parent_hash(&parent_hash)
             .await;
 
+        let builder_healthy = matches!(self.probes.health(), Health::Healthy);
+
         // async call to builder to sync the builder node
         if !self.execution_mode().is_disabled()
-            && (self.allow_traffic_to_unhealthy_builder
-                || matches!(self.probes.health(), Health::Healthy))
+            && (self.allow_traffic_to_unhealthy_builder || builder_healthy)
         {
             let builder = self.builder_client.clone();
             let new_payload_clone = new_payload.clone();

--- a/crates/rollup-boost/src/tests/common/mod.rs
+++ b/crates/rollup-boost/src/tests/common/mod.rs
@@ -232,6 +232,8 @@ pub struct RollupBoostTestHarnessBuilder {
     isthmus_block: Option<u64>,
     block_time: u64,
     use_l2_client_for_state_root: bool,
+    allow_traffic_to_unhealthy_builder: Option<bool>,
+    max_unsafe_interval: Option<u64>,
 }
 
 impl RollupBoostTestHarnessBuilder {
@@ -242,6 +244,8 @@ impl RollupBoostTestHarnessBuilder {
             isthmus_block: None,
             block_time: 1,
             use_l2_client_for_state_root: false,
+            allow_traffic_to_unhealthy_builder: None,
+            max_unsafe_interval: None,
         }
     }
 
@@ -294,6 +298,16 @@ impl RollupBoostTestHarnessBuilder {
 
     pub fn with_l2_state_root_computation(mut self, enabled: bool) -> Self {
         self.use_l2_client_for_state_root = enabled;
+        self
+    }
+
+    pub fn with_allow_traffic_to_unhealthy_builder(mut self, enabled: bool) -> Self {
+        self.allow_traffic_to_unhealthy_builder = Some(enabled);
+        self
+    }
+
+    pub fn with_max_unsafe_interval(mut self, interval_secs: u64) -> Self {
+        self.max_unsafe_interval = Some(interval_secs);
         self
     }
 
@@ -371,6 +385,12 @@ impl RollupBoostTestHarnessBuilder {
         rollup_boost.args.builder.builder_url = builder_url.try_into().unwrap();
         rollup_boost.args.log_file = Some(rollup_boost_log_file_path);
         rollup_boost.args.use_l2_client_for_state_root = self.use_l2_client_for_state_root;
+        if let Some(allow_traffic) = self.allow_traffic_to_unhealthy_builder {
+            rollup_boost.args.allow_traffic_to_unhealthy_builder = allow_traffic;
+        }
+        if let Some(interval) = self.max_unsafe_interval {
+            rollup_boost.args.max_unsafe_interval = interval;
+        }
         let rollup_boost = rollup_boost.start().await;
         println!("rollup-boost authrpc: {}", rollup_boost.rpc_endpoint());
         println!("rollup-boost metrics: {}", rollup_boost.metrics_endpoint());

--- a/crates/rollup-boost/src/tests/common/services/rollup_boost.rs
+++ b/crates/rollup-boost/src/tests/common/services/rollup_boost.rs
@@ -52,6 +52,8 @@ impl Default for RollupBoostConfig {
             &format!("--builder-jwt-path={}/jwt_secret.hex", *TEST_DATA),
             "--log-level=trace",
             "--health-check-interval=1", // Set health check interval to 1 second for tests
+            "--max-unsafe-interval=60",  // Increase max unsafe interval for tests
+            "--allow-traffic-to-unhealthy-builder", // Allow all engine API calls to unhealthy builder for tests
         ]);
 
         args.rpc_port = get_available_port();

--- a/crates/rollup-boost/src/tests/common/services/rollup_boost.rs
+++ b/crates/rollup-boost/src/tests/common/services/rollup_boost.rs
@@ -51,6 +51,7 @@ impl Default for RollupBoostConfig {
             &format!("--l2-jwt-path={}/jwt_secret.hex", *TEST_DATA),
             &format!("--builder-jwt-path={}/jwt_secret.hex", *TEST_DATA),
             "--log-level=trace",
+            "--health-check-interval=1", // Set health check interval to 1 second for tests
         ]);
 
         args.rpc_port = get_available_port();

--- a/crates/rollup-boost/src/tests/execution_mode.rs
+++ b/crates/rollup-boost/src/tests/execution_mode.rs
@@ -13,11 +13,17 @@ struct CounterHandler {
 impl BuilderProxyHandler for CounterHandler {
     fn handle(
         &self,
-        _method: String,
+        method: String,
         _params: Value,
         _result: Value,
     ) -> Pin<Box<dyn Future<Output = Option<Value>> + Send>> {
-        *self.counter.lock().unwrap() += 1;
+        // Only count Engine API calls, not health check calls
+        if method != "eth_getBlockByNumber" {
+            *self.counter.lock().unwrap() += 1;
+            tracing::info!("Proxy handler intercepted Engine API call: {}", method);
+        } else {
+            tracing::debug!("Proxy handler intercepted health check call: {}", method);
+        }
         async move { None }.boxed()
     }
 }

--- a/crates/rollup-boost/src/tests/mod.rs
+++ b/crates/rollup-boost/src/tests/mod.rs
@@ -10,3 +10,4 @@ mod remote_builder_down;
 mod simple;
 mod simple_isthmus;
 mod simple_isthmus_transition;
+mod unhealthy_builder_traffic;

--- a/crates/rollup-boost/src/tests/no_tx_pool.rs
+++ b/crates/rollup-boost/src/tests/no_tx_pool.rs
@@ -1,10 +1,14 @@
 use super::common::RollupBoostTestHarnessBuilder;
+use std::time::Duration;
 
 #[tokio::test]
 async fn no_tx_pool() -> eyre::Result<()> {
     let harness = RollupBoostTestHarnessBuilder::new("no_tx_pool")
         .build()
         .await?;
+
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
     let mut block_generator = harness.block_generator().await?;
 
     // start creating 5 empty blocks which are processed by the L2 builder

--- a/crates/rollup-boost/src/tests/no_tx_pool.rs
+++ b/crates/rollup-boost/src/tests/no_tx_pool.rs
@@ -1,13 +1,10 @@
 use super::common::RollupBoostTestHarnessBuilder;
-use std::time::Duration;
 
 #[tokio::test]
 async fn no_tx_pool() -> eyre::Result<()> {
     let harness = RollupBoostTestHarnessBuilder::new("no_tx_pool")
         .build()
         .await?;
-
-    tokio::time::sleep(Duration::from_secs(5)).await;
 
     let mut block_generator = harness.block_generator().await?;
 

--- a/crates/rollup-boost/src/tests/remote_builder_down.rs
+++ b/crates/rollup-boost/src/tests/remote_builder_down.rs
@@ -35,7 +35,7 @@ async fn remote_builder_down() -> eyre::Result<()> {
     // Generate a new block so that the builder can use the FCU request
     // to sync up the missing blocks with the L2 client
     let _ = block_generator.generate_block(false).await?;
-    tokio::time::sleep(Duration::from_secs(10)).await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
 
     // create 3 new blocks that are processed by the l2 builder because the builder is not synced with the previous 3 blocks
     for _ in 0..3 {

--- a/crates/rollup-boost/src/tests/remote_builder_down.rs
+++ b/crates/rollup-boost/src/tests/remote_builder_down.rs
@@ -35,7 +35,7 @@ async fn remote_builder_down() -> eyre::Result<()> {
     // Generate a new block so that the builder can use the FCU request
     // to sync up the missing blocks with the L2 client
     let _ = block_generator.generate_block(false).await?;
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    tokio::time::sleep(Duration::from_secs(10)).await;
 
     // create 3 new blocks that are processed by the l2 builder because the builder is not synced with the previous 3 blocks
     for _ in 0..3 {

--- a/crates/rollup-boost/src/tests/unhealthy_builder_traffic.rs
+++ b/crates/rollup-boost/src/tests/unhealthy_builder_traffic.rs
@@ -1,0 +1,110 @@
+use super::common::{RollupBoostTestHarnessBuilder, proxy::BuilderProxyHandler};
+use crate::ExecutionMode;
+use futures::FutureExt as _;
+use serde_json::Value;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+struct CounterHandler {
+    counter: Arc<Mutex<u32>>,
+}
+
+impl BuilderProxyHandler for CounterHandler {
+    fn handle(
+        &self,
+        method: String,
+        _params: Value,
+        _result: Value,
+    ) -> Pin<Box<dyn Future<Output = Option<Value>> + Send>> {
+        // Only count Engine API calls, not health check calls
+        if method != "eth_getBlockByNumber" {
+            *self.counter.lock().unwrap() += 1;
+            tracing::info!("Proxy handler intercepted Engine API call: {}", method);
+        } else {
+            tracing::debug!("Proxy handler intercepted health check call: {}", method);
+        }
+        async move { None }.boxed()
+    }
+}
+
+#[tokio::test]
+async fn no_traffic_to_unhealthy_builder_when_flag_disabled() -> eyre::Result<()> {
+    // Create a counter that tracks Engine API calls to the builder
+    let counter = Arc::new(Mutex::new(0));
+    let handler = Arc::new(CounterHandler {
+        counter: counter.clone(),
+    });
+
+    // Create test harness with:
+    // - allow_traffic_to_unhealthy_builder=false (key test parameter)
+    // - short max_unsafe_interval=1 to make builder unhealthy quickly
+    let harness = RollupBoostTestHarnessBuilder::new("no_traffic_unhealthy")
+        .proxy_handler(handler)
+        .with_allow_traffic_to_unhealthy_builder(false)
+        .with_max_unsafe_interval(1)
+        .build()
+        .await?;
+
+    // Override max_unsafe_interval to 1 second for this test
+    // We'll need to modify the config after build - let's access the rollup boost args
+
+    let mut block_generator = harness.block_generator().await?;
+    let client = harness.debug_client().await;
+
+    // Step 1: Disable execution mode so L2 moves ahead and builder falls behind
+    let response = client
+        .set_execution_mode(ExecutionMode::Disabled)
+        .await
+        .unwrap();
+    assert_eq!(response.execution_mode, ExecutionMode::Disabled);
+
+    // Step 2: Let L2 move ahead by generating some blocks
+    for _ in 0..3 {
+        let (_block, block_creator) = block_generator.generate_block(false).await?;
+        assert!(
+            block_creator.is_l2(),
+            "Blocks should be created by L2 when execution disabled"
+        );
+    }
+
+    // Step 3: Re-enable execution mode
+    let response = client
+        .set_execution_mode(ExecutionMode::Enabled)
+        .await
+        .unwrap();
+    assert_eq!(response.execution_mode, ExecutionMode::Enabled);
+
+    // Step 4:Wait for health check to run again and mark builder as unhealthy
+    // since execution mode is now enabled and builder timestamp is stale
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Reset counter after builder should be marked unhealthy
+    *counter.lock().unwrap() = 0;
+
+    // Step 5: Generate blocks - builder should now be unhealthy and with flag=false,
+    // no engine API calls should go to the builder
+    for i in 0..5 {
+        let (_block, block_creator) = block_generator.generate_block(false).await?;
+        println!("Block {}: created by {:?}", i + 1, block_creator);
+        // Blocks should be created by L2 since builder is unhealthy and flag is false
+        assert!(
+            block_creator.is_l2(),
+            "Block creator should be L2 when builder is unhealthy and flag is false"
+        );
+    }
+
+    let final_count = *counter.lock().unwrap();
+    println!(
+        "Engine API calls to builder with allow_traffic_to_unhealthy_builder=false: {}",
+        final_count
+    );
+
+    // With flag=false and unhealthy builder, should see zero engine API calls
+    assert_eq!(
+        final_count, 0,
+        "Should see no Engine API calls to unhealthy builder when flag is false"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Builder EL automatically does EL sync when it receives a future FCU, adding this change so that rollup-boost does not send any engine api request to the builder EL and the builder EL will always rely on its CL to sync to the tip.

Tested on sepolia-alpha and it allows a builder to sync to the tip within 10 mins from a snapshot.

Ran `cargo test`, all tests pass locally