### PR TITLE
Add logging for proxying to the builder

### DIFF
--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -137,7 +137,7 @@ impl RollupBoostServer {
                 message = "Allow new_payload to builder",
                 allow_traffic_to_unhealthy_builder = self.allow_traffic_to_unhealthy_builder,
                 builder_healthy = builder_healthy,
-                execution_mode = self.execution_mode().is_disabled()
+                execution_mode = self.execution_mode().is_enabled()
             );
             let builder = self.builder_client.clone();
             let new_payload_clone = new_payload.clone();
@@ -202,8 +202,8 @@ impl RollupBoostServer {
             info!(
                 message = "Allow get_payload to builder",
                 allow_traffic_to_unhealthy_builder = self.allow_traffic_to_unhealthy_builder,
-                builder_healthy = builder_healthy,
-                execution_mode = self.execution_mode().is_disabled()
+                builder_healthy = matches!(self.probes.health(), Health::Healthy),
+                execution_mode = self.execution_mode().is_enabled()
             );
 
             if !self.allow_traffic_to_unhealthy_builder
@@ -452,7 +452,7 @@ impl EngineApiServer for RollupBoostServer {
             message = "Allow FCU to builder",
             allow_traffic_to_unhealthy_builder = self.allow_traffic_to_unhealthy_builder,
             builder_healthy = builder_healthy,
-            execution_mode = self.execution_mode().is_disabled()
+            execution_mode = self.execution_mode().is_enabled()
         );
 
         let span = tracing::Span::current();

--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -68,6 +68,7 @@ impl RollupBoostServer {
         use_l2_client_for_state_root: bool,
         allow_traffic_to_unhealthy_builder: bool,
     ) -> Self {
+        info!("allow traffic to unhealthy builder: {}", allow_traffic_to_unhealthy_builder);
         Self {
             l2_client: Arc::new(l2_client),
             builder_client,

--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -68,7 +68,6 @@ impl RollupBoostServer {
         use_l2_client_for_state_root: bool,
         allow_traffic_to_unhealthy_builder: bool,
     ) -> Self {
-        info!("allow traffic to unhealthy builder: {}", allow_traffic_to_unhealthy_builder);
         Self {
             l2_client: Arc::new(l2_client),
             builder_client,
@@ -130,14 +129,16 @@ impl RollupBoostServer {
 
         let builder_healthy = matches!(self.probes.health(), Health::Healthy);
 
-        info!("allow traffic to unhealthy builder: {}", self.allow_traffic_to_unhealthy_builder);
-        info!("builder healthy: {}", builder_healthy);
-        info!("execution mode: {}", self.execution_mode().is_disabled());
-
         // async call to builder to sync the builder node
         if !self.execution_mode().is_disabled()
             && (self.allow_traffic_to_unhealthy_builder || builder_healthy)
         {
+            info!(
+                message = "Allow new_payload to builder",
+                allow_traffic_to_unhealthy_builder = self.allow_traffic_to_unhealthy_builder,
+                builder_healthy = builder_healthy,
+                execution_mode = self.execution_mode().is_disabled()
+            );
             let builder = self.builder_client.clone();
             let new_payload_clone = new_payload.clone();
             tokio::spawn(async move { builder.new_payload(new_payload_clone).await });
@@ -198,9 +199,12 @@ impl RollupBoostServer {
                 return RpcResult::Ok(None);
             }
 
-            info!("allow traffic to unhealthy builder: {}", self.allow_traffic_to_unhealthy_builder);
-            info!("builder healthy: {}", matches!(self.probes.health(), Health::Healthy));
-            info!("execution mode: {}", self.execution_mode().is_disabled());
+            info!(
+                message = "Allow get_payload to builder",
+                allow_traffic_to_unhealthy_builder = self.allow_traffic_to_unhealthy_builder,
+                builder_healthy = builder_healthy,
+                execution_mode = self.execution_mode().is_disabled()
+            );
 
             if !self.allow_traffic_to_unhealthy_builder
                 && !matches!(self.probes.health(), Health::Healthy)
@@ -439,14 +443,17 @@ impl EngineApiServer for RollupBoostServer {
             return Ok(l2_fut.await?);
         }
 
-        info!("allow traffic to unhealthy builder: {}", self.allow_traffic_to_unhealthy_builder);
-        info!("builder healthy: {}", builder_healthy);
-        info!("execution mode: {}", self.execution_mode().is_disabled());
-
         if !self.allow_traffic_to_unhealthy_builder && !builder_healthy {
             info!(message = "builder is unhealthy, skipping FCU to builder");
             return Ok(l2_fut.await?);
         }
+
+        info!(
+            message = "Allow FCU to builder",
+            allow_traffic_to_unhealthy_builder = self.allow_traffic_to_unhealthy_builder,
+            builder_healthy = builder_healthy,
+            execution_mode = self.execution_mode().is_disabled()
+        );
 
         let span = tracing::Span::current();
         // If the fcu contains payload attributes and the tx pool is disabled,

--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -130,6 +130,10 @@ impl RollupBoostServer {
 
         let builder_healthy = matches!(self.probes.health(), Health::Healthy);
 
+        info!("allow traffic to unhealthy builder: {}", self.allow_traffic_to_unhealthy_builder);
+        info!("builder healthy: {}", builder_healthy);
+        info!("execution mode: {}", self.execution_mode().is_disabled());
+
         // async call to builder to sync the builder node
         if !self.execution_mode().is_disabled()
             && (self.allow_traffic_to_unhealthy_builder || builder_healthy)
@@ -193,6 +197,10 @@ impl RollupBoostServer {
                 tracing::Span::current().record("builder_has_payload", false);
                 return RpcResult::Ok(None);
             }
+
+            info!("allow traffic to unhealthy builder: {}", self.allow_traffic_to_unhealthy_builder);
+            info!("builder healthy: {}", matches!(self.probes.health(), Health::Healthy));
+            info!("execution mode: {}", self.execution_mode().is_disabled());
 
             if !self.allow_traffic_to_unhealthy_builder
                 && !matches!(self.probes.health(), Health::Healthy)
@@ -430,6 +438,10 @@ impl EngineApiServer for RollupBoostServer {
         if self.execution_mode().is_disabled() {
             return Ok(l2_fut.await?);
         }
+
+        info!("allow traffic to unhealthy builder: {}", self.allow_traffic_to_unhealthy_builder);
+        info!("builder healthy: {}", builder_healthy);
+        info!("execution mode: {}", self.execution_mode().is_disabled());
 
         if !self.allow_traffic_to_unhealthy_builder && !builder_healthy {
             info!(message = "builder is unhealthy, skipping FCU to builder");


### PR DESCRIPTION
Mainnet seems to still be sending traffic to the builder, can't reproduce on sepolia-alpha thus adding more logs.