### PR TITLE
always healthcheck non disabled

### DIFF
--- a/crates/rollup-boost/src/health.rs
+++ b/crates/rollup-boost/src/health.rs
@@ -54,7 +54,7 @@ impl HealthHandle {
                     Ok(block) => block,
                     Err(e) => {
                         warn!(target: "rollup_boost::health", "Failed to get unsafe block from builder client: {} - updating health status", e);
-                        if self.execution_mode.lock().is_enabled() {
+                        if !self.execution_mode.lock().is_disabled() {
                             self.probes.set_health(Health::PartialContent);
                         }
                         sleep_until(Instant::now() + self.health_check_interval).await;
@@ -67,7 +67,7 @@ impl HealthHandle {
                     .gt(&self.max_unsafe_interval)
                 {
                     warn!(target: "rollup_boost::health", curr_unix = %t, unsafe_unix = %latest_unsafe.header.timestamp, "Unsafe block timestamp is too old updating health status");
-                    if self.execution_mode.lock().is_enabled() {
+                    if !self.execution_mode.lock().is_disabled() {
                         self.probes.set_health(Health::PartialContent);
                     }
                 } else {


### PR DESCRIPTION
Currently it's only marking unhealthy if execution_mode is enabled, but mainnet we are on dry run mode right now but we need to use the healthcheck, thus changing it to always healthcheck when execution mode is not disabled instead.