### PR TITLE
debug api to force override health status

### DIFF
--- a/crates/rollup-boost/src/cli.rs
+++ b/crates/rollup-boost/src/cli.rs
@@ -35,7 +35,7 @@ pub struct Args {
     pub l2_client: L2ClientArgs,
 
     /// Duration in seconds between async health checks on the builder
-    #[arg(long, env, default_value = "60")]
+    #[arg(long, env, default_value = "5")]
     pub health_check_interval: u64,
 
     /// Max duration in seconds between the unsafe head block of the builder and the current time

--- a/crates/rollup-boost/src/health.rs
+++ b/crates/rollup-boost/src/health.rs
@@ -9,7 +9,7 @@ use tokio::{
     task::JoinHandle,
     time::{Instant, sleep_until},
 };
-use tracing::warn;
+use tracing::{info, warn};
 
 use crate::{EngineApiExt, ExecutionMode, Health, Probes};
 
@@ -43,6 +43,7 @@ impl HealthHandle {
     /// the current time minus the max_unsafe_interval.
     pub fn spawn(self) -> JoinHandle<()> {
         tokio::spawn(async move {
+            info!(target: "rollup_boost::health", "running health check");
             let mut timestamp = MonotonicTimestamp::new();
 
             loop {

--- a/crates/rollup-boost/src/probe.rs
+++ b/crates/rollup-boost/src/probe.rs
@@ -16,7 +16,8 @@ use tracing::warn;
 
 use crate::{Request, Response};
 
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum Health {
     /// Indicates that the builder is building blocks
     #[default]

--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -98,7 +98,7 @@ impl RollupBoostServer {
     }
 
     pub async fn start_debug_server(&self, debug_addr: &str) -> eyre::Result<()> {
-        let server = DebugServer::new(self.execution_mode.clone());
+        let server = DebugServer::new(self.execution_mode.clone(), self.probes.clone());
         server.run(debug_addr).await?;
         Ok(())
     }


### PR DESCRIPTION
usage:

```
curl -X POST http://localhost:5555 -H "Content-Type:
  application/json" \
  -d '{"jsonrpc":"2.0","method":"debug_setHealthOverride","params":{
  "health":"partial_content"},"id":1}'
```

```
curl -X POST http://localhost:5555 -H "Content-Type:
  application/json" \
  -d '{"jsonrpc":"2.0","method":"debug_setHealthOverride","params":{
  "health":"healthy"},"id":1}'
```