### PR TITLE
fallback to EL for state root if config AND state root is zero

### DIFF
--- a/crates/rollup-boost/src/payload.rs
+++ b/crates/rollup-boost/src/payload.rs
@@ -134,6 +134,24 @@ impl OpExecutionPayloadEnvelope {
             },
         }
     }
+
+    pub fn state_root(&self) -> B256 {
+        match self {
+            OpExecutionPayloadEnvelope::V3(payload) => payload
+                .execution_payload
+                .payload_inner
+                .payload_inner
+                .state_root
+                .into(),
+            OpExecutionPayloadEnvelope::V4(payload) => payload
+                .execution_payload
+                .payload_inner
+                .payload_inner
+                .payload_inner
+                .state_root
+                .into(),
+        }
+    }
 }
 
 impl From<OpExecutionPayloadEnvelope> for ExecutionPayload {

--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -206,7 +206,10 @@ impl RollupBoostServer {
 
             let payload = self.builder_client.get_payload(payload_id, version).await?;
 
-            if self.use_l2_client_for_state_root == false {
+            let should_use_l2_client_for_state_root =
+                self.use_l2_client_for_state_root && payload.state_root() == B256::ZERO;
+
+            if !should_use_l2_client_for_state_root {
                 let _ = self
                     .l2_client
                     .new_payload(NewPayload::from(payload.clone()))


### PR DESCRIPTION
works in conjunction with https://github.com/base/op-rbuilder/pull/5
