### PR TITLE
Separate rate limiting metrics by limit type

### DIFF
--- a/crates/websocket-proxy/src/metrics.rs
+++ b/crates/websocket-proxy/src/metrics.rs
@@ -21,8 +21,11 @@ pub struct Metrics {
     #[metric(describe = "Number of client connections currently open")]
     pub active_connections: Gauge,
 
-    #[metric(describe = "Count of rate limited request")]
-    pub rate_limited_requests: Counter,
+    #[metric(describe = "Count of requests rate limited due to per-IP limits")]
+    pub per_ip_rate_limited_requests: Counter,
+
+    #[metric(describe = "Count of requests rate limited due to global instance limits")]
+    pub global_rate_limited_requests: Counter,
 
     #[metric(describe = "Count of unauthorized requests with invalid API keys")]
     pub unauthorized_requests: Counter,

--- a/crates/websocket-proxy/src/server.rs
+++ b/crates/websocket-proxy/src/server.rs
@@ -239,6 +239,11 @@ fn websocket_handler(
         Err(RateLimitError::Limit { reason, limit_type }) => {
             match limit_type {
                 RateLimitType::PerIp => {
+                    info!(
+                        message = "per-IP rate limit exceeded",
+                        client_ip = client_addr.to_string(),
+                        reason = reason
+                    );
                     state.metrics.per_ip_rate_limited_requests.increment(1);
                 }
                 RateLimitType::Global => {

--- a/crates/websocket-proxy/src/server.rs
+++ b/crates/websocket-proxy/src/server.rs
@@ -2,7 +2,7 @@ use crate::auth::Authentication;
 use crate::client::ClientConnection;
 use crate::filter::{FilterType, MatchMode};
 use crate::metrics::Metrics;
-use crate::rate_limit::{RateLimit, RateLimitError};
+use crate::rate_limit::{RateLimit, RateLimitError, RateLimitType};
 use crate::registry::Registry;
 use axum::body::Body;
 use axum::extract::{ConnectInfo, Path, Query, State, WebSocketUpgrade};
@@ -236,8 +236,15 @@ fn websocket_handler(
 
     let ticket = match state.rate_limiter.try_acquire(client_addr) {
         Ok(ticket) => ticket,
-        Err(RateLimitError::Limit { reason }) => {
-            state.metrics.rate_limited_requests.increment(1);
+        Err(RateLimitError::Limit { reason, limit_type }) => {
+            match limit_type {
+                RateLimitType::PerIp => {
+                    state.metrics.per_ip_rate_limited_requests.increment(1);
+                }
+                RateLimitType::Global => {
+                    state.metrics.global_rate_limited_requests.increment(1);
+                }
+            }
 
             return Response::builder()
                 .status(StatusCode::TOO_MANY_REQUESTS)


### PR DESCRIPTION
Split the single `rate_limited_requests` metric into two separate counters:
- `per_ip_rate_limited_requests`: Tracks rejections due to per-IP connection limits
- `global_rate_limited_requests`: Tracks rejections due to global instance limits

This provides better observability into which rate limiting mechanism is being triggered, enabling more targeted monitoring and alerting.

Changes:
- Add RateLimitType enum to distinguish between limit types
- Update RateLimitError to include limit_type field
- Modify server.rs to increment appropriate metric based on limit type
- Update both InMemoryRateLimit and RedisRateLimit implementations

🤖 Generated with [Claude Code](https://claude.ai/code)