### PR TITLE
Only mark builder unhealthy on API failures, not L2 processing failures

### DIFF
--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -1258,39 +1258,10 @@ pub mod tests {
             // Builder should also return same payload ID for FCU
             builder_mock.fcu_response = Ok(ForkchoiceUpdated::new(PayloadStatus::from_status(PayloadStatusEnum::Valid))
                 .with_payload_id(PayloadId::new([0, 0, 0, 0, 0, 0, 0, 2])));
-            // Builder API succeeds
-            builder_mock.get_payload_response = Ok(OpExecutionPayloadEnvelopeV3{
-                execution_payload: ExecutionPayloadV3 {
-                        payload_inner: ExecutionPayloadV2 {
-                            payload_inner: ExecutionPayloadV1 {
-                                base_fee_per_gas:  U256::from(7u64),
-                                block_number: 0xa946u64,
-                                block_hash: hex!("a5ddd3f286f429458a39cafc13ffe89295a7efa8eb363cf89a1a4887dbcf272b").into(),
-                                logs_bloom: hex!("00200004000000000000000080000000000200000000000000000000000000000000200000000000000000000000000000000000800000000200000000000000000000000000000000000008000000200000000000000000000001000000000000000000000000000000800000000000000000000100000000000030000000000000000040000000000000000000000000000000000800080080404000000000000008000000000008200000000000200000000000000000000000000000000000000002000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000100000000000000000000").into(),
-                                extra_data: hex!("d883010d03846765746888676f312e32312e31856c696e7578").into(),
-                                gas_limit: 0x1c9c380,
-                                gas_used: 0x1f4a9,
-                                timestamp: 0x651f35b8,
-                                fee_recipient: hex!("f97e180c050e5ab072211ad2c213eb5aee4df134").into(),
-                                parent_hash: hex!("d829192799c73ef28a7332313b3c03af1f2d5da2c36f8ecfafe7a83a3bfb8d1e").into(),
-                                prev_randao: hex!("753888cc4adfbeb9e24e01c84233f9d204f4a9e1273f0e29b43c4c148b2b8b7e").into(),
-                                receipts_root: hex!("4cbc48e87389399a0ea0b382b1c46962c4b8e398014bf0cc610f9c672bee3155").into(),
-                                state_root: hex!("017d7fa2b5adb480f5e05b2c95cb4186e12062eed893fc8822798eed134329d1").into(),
-                                transactions: vec![],
-                            },
-                            withdrawals: vec![],
-                        },
-                        blob_gas_used: 0xc0000,
-                    excess_blob_gas: 0x580000,
-                },
-                block_value: U256::from(15),
-                blobs_bundle: BlobsBundleV1{
-                    commitments: vec![],
-                    proofs: vec![],
-                    blobs: vec![],
-                },
-                should_override_builder: false,
-                parent_beacon_block_root: B256::ZERO,
+            // Builder API succeeds - just modify the block value from default
+            builder_mock.get_payload_response = builder_mock.get_payload_response.clone().map(|mut payload| {
+                payload.block_value = U256::from(15);
+                payload
             });
 
             let test_harness = TestHarness::new(Some(l2_mock), Some(builder_mock)).await;

--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -215,7 +215,6 @@ impl RollupBoostServer {
             };
 
             if self.use_l2_client_for_state_root == false {
-                // If L2 validation fails, it's a processing error, not builder API error
                 match self
                     .l2_client
                     .new_payload(NewPayload::from(payload.clone()))
@@ -254,7 +253,6 @@ impl RollupBoostServer {
                 },
             };
             
-            // If L2 FCU fails, it's a processing error, not builder API error
             let l2_result = match self
                 .l2_client
                 .fork_choice_updated_v3(fcu_info.0, Some(new_payload_attrs))
@@ -262,7 +260,7 @@ impl RollupBoostServer {
             {
                 Ok(result) => result,
                 Err(e) => {
-                    error!(message = "L2 FCU failed, but builder API succeeded", error = %e);
+                    error!(message = "L2 FCU failed, failed to start state root calculation", error = %e);
                     return Ok((None, false)); // L2 processing failed, not builder API
                 }
             };
@@ -285,7 +283,7 @@ impl RollupBoostServer {
                     }
 
                     Err(e) => {
-                        error!(message = "L2 get_payload failed, but builder API succeeded", error = %e);
+                        error!(message = "error getting new state root payload from l2", error = %e);
                         return Ok((None, false)); // L2 processing failed, not builder API
                     }
                 }
@@ -302,12 +300,12 @@ impl RollupBoostServer {
                 l2_payload.inspect_err(|_| self.probes.set_health(Health::ServiceUnavailable))?;
             self.probes.set_health(Health::Healthy);
 
-            // Extract builder payload and whether builder API failed
+            // Convert Result<Option<Payload>> to Option<Payload> by extracting the inner Option.
             let (builder_payload, builder_api_failed) = match builder_result {
                 Ok((payload, api_failed)) => (payload, api_failed),
                 Err(e) => {
-                    error!(message = "error in builder future", error = %e);
-                    (None, false) // Future failed, but not necessarily builder API
+                    error!(message = "error getting payload from builder", error = %e);
+                    (None, false)
                 }
             };
 
@@ -334,7 +332,7 @@ impl RollupBoostServer {
                     (builder_payload, PayloadSource::Builder)
                 }
             } else {
-                // Only update the health status if the builder API itself failed
+                // Only update the health status if the builder payload fails
                 // and execution mode is not set to DryRun
                 if builder_api_failed && !self.execution_mode().is_dry_run() {
                     self.probes.set_health(Health::PartialContent);
@@ -950,10 +948,10 @@ pub mod tests {
             assert_eq!(*req, PayloadId::new([0, 0, 0, 0, 0, 0, 0, 1]));
         }
 
-        // Now that a block has been produced by the l2 but the builder was never asked to build
-        // (FCU without payload attributes), the health status should remain Healthy
+        // Now that a block has been produced by the l2 but not the builder
+        // the health status should be Partial Content
         let health = test_harness.get("healthz").await;
-        assert_eq!(health.status(), StatusCode::OK);
+        assert_eq!(health.status(), StatusCode::PARTIAL_CONTENT);
 
         test_harness.cleanup().await;
     }

--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -179,7 +179,8 @@ impl RollupBoostServer {
         }
 
         // Forward the get payload request to the builder
-        let builder_fut = async {
+        // Returns (payload_option, builder_api_failed)  
+        let builder_fut: std::pin::Pin<Box<dyn std::future::Future<Output = Result<(Option<OpExecutionPayloadEnvelope>, bool), jsonrpsee::types::ErrorObject<'static>>> + Send>> = Box::pin(async {
             if let Some(cause) = self.payload_trace_context.trace_id(&payload_id).await {
                 tracing::Span::current().follows_from(cause);
             }
@@ -190,29 +191,42 @@ impl RollupBoostServer {
             {
                 info!(message = "builder has no payload, skipping get_payload call to builder");
                 tracing::Span::current().record("builder_has_payload", false);
-                return RpcResult::Ok(None);
+                return Ok((None, true));
             }
 
             if !self.allow_traffic_to_unhealthy_builder
                 && !matches!(self.probes.health(), Health::Healthy)
             {
                 info!(message = "builder is unhealthy, skipping get_payload call to builder");
-                return RpcResult::Ok(None);
+                return Ok((None, true));
             }
 
             // Get payload and validate with the local l2 client
             tracing::Span::current().record("builder_has_payload", true);
             info!(message = "builder has payload, calling get_payload on builder");
 
-            let payload = self.builder_client.get_payload(payload_id, version).await?;
+            // Try to get payload from builder - this is the critical API call
+            let payload = match self.builder_client.get_payload(payload_id, version).await {
+                Ok(payload) => payload,
+                Err(e) => {
+                    error!(message = "builder get_payload API failed", error = %e);
+                    return Ok((None, true)); // Builder API failed
+                }
+            };
 
             if self.use_l2_client_for_state_root == false {
-                let _ = self
+                // If L2 validation fails, it's a processing error, not builder API error
+                match self
                     .l2_client
                     .new_payload(NewPayload::from(payload.clone()))
-                    .await?;
-
-                return Ok(Some(payload));
+                    .await
+                {
+                    Ok(_) => return Ok((Some(payload), false)),
+                    Err(e) => {
+                        error!(message = "L2 validation failed, but builder API succeeded", error = %e);
+                        return Ok((None, false)); // L2 processing failed, not builder API
+                    }
+                }
             }
 
             let fcu_info = self
@@ -239,10 +253,19 @@ impl RollupBoostServer {
                     eip_1559_params: None,
                 },
             };
-            let l2_result = self
+            
+            // If L2 FCU fails, it's a processing error, not builder API error
+            let l2_result = match self
                 .l2_client
                 .fork_choice_updated_v3(fcu_info.0, Some(new_payload_attrs))
-                .await?;
+                .await
+            {
+                Ok(result) => result,
+                Err(e) => {
+                    error!(message = "L2 FCU failed, but builder API succeeded", error = %e);
+                    return Ok((None, false)); // L2 processing failed, not builder API
+                }
+            };
 
             if let Some(new_payload_id) = l2_result.payload_id {
                 debug!(
@@ -258,20 +281,20 @@ impl RollupBoostServer {
                             message = "received new state root payload from l2",
                             payload = ?new_payload,
                         );
-                        return Ok(Some(new_payload));
+                        return Ok((Some(new_payload), false));
                     }
 
                     Err(e) => {
-                        error!(message = "error getting new state root payload from l2", error = %e);
-                        return Err(e.into());
+                        error!(message = "L2 get_payload failed, but builder API succeeded", error = %e);
+                        return Ok((None, false)); // L2 processing failed, not builder API
                     }
                 }
             }
 
-            Ok(None)
-        };
+            Ok((None, false))
+        });
 
-        let (builder_payload, l2_payload) = tokio::join!(builder_fut, l2_fut);
+        let (builder_result, l2_payload) = tokio::join!(builder_fut, l2_fut);
 
         // Evaluate the builder and l2 response and select the final payload
         let (payload, context) = {
@@ -279,14 +302,14 @@ impl RollupBoostServer {
                 l2_payload.inspect_err(|_| self.probes.set_health(Health::ServiceUnavailable))?;
             self.probes.set_health(Health::Healthy);
 
-            // Convert Result<Option<Payload>> to Option<Payload> by extracting the inner Option.
-            // If there's an error, log it and return None instead.
-            let builder_payload = builder_payload
-                .map_err(|e| {
-                    error!(message = "error getting payload from builder", error = %e);
-                    e
-                })
-                .unwrap_or(None);
+            // Extract builder payload and whether builder API failed
+            let (builder_payload, builder_api_failed) = match builder_result {
+                Ok((payload, api_failed)) => (payload, api_failed),
+                Err(e) => {
+                    error!(message = "error in builder future", error = %e);
+                    (None, false) // Future failed, but not necessarily builder API
+                }
+            };
 
             if let Some(builder_payload) = builder_payload {
                 // Record the delta (gas and txn) between the builder and l2 payload
@@ -311,9 +334,9 @@ impl RollupBoostServer {
                     (builder_payload, PayloadSource::Builder)
                 }
             } else {
-                // Only update the health status if the builder payload fails
+                // Only update the health status if the builder API itself failed
                 // and execution mode is not set to DryRun
-                if !self.execution_mode().is_dry_run() {
+                if builder_api_failed && !self.execution_mode().is_dry_run() {
                     self.probes.set_health(Health::PartialContent);
                 }
                 (l2_payload, PayloadSource::L2)
@@ -927,10 +950,10 @@ pub mod tests {
             assert_eq!(*req, PayloadId::new([0, 0, 0, 0, 0, 0, 0, 1]));
         }
 
-        // Now that a block has been produced by the l2 but not the builder
-        // the health status should be Partial Content
+        // Now that a block has been produced by the l2 but the builder was never asked to build
+        // (FCU without payload attributes), the health status should remain Healthy
         let health = test_harness.get("healthz").await;
-        assert_eq!(health.status(), StatusCode::PARTIAL_CONTENT);
+        assert_eq!(health.status(), StatusCode::OK);
 
         test_harness.cleanup().await;
     }

--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -1183,4 +1183,147 @@ pub mod tests {
             .await;
         assert!(fcu_response.is_err());
     }
+
+    #[tokio::test]
+    async fn builder_api_failure_vs_processing_failure() {
+        // Test that only builder API failures mark builder as unhealthy,
+        // not L2 processing failures after successful builder API calls
+        
+        // Test 1: Builder API failure should mark as unhealthy
+        {
+            let mut l2_mock = MockEngineServer::new();
+            // Ensure L2 returns a payload ID
+            l2_mock.fcu_response = Ok(ForkchoiceUpdated::new(PayloadStatus::from_status(PayloadStatusEnum::Valid))
+                .with_payload_id(PayloadId::new([0, 0, 0, 0, 0, 0, 0, 1])));
+
+            let mut builder_mock = MockEngineServer::new();
+            // Make builder API fail
+            builder_mock.get_payload_response = Err(ErrorObject::owned(
+                INVALID_REQUEST_CODE,
+                "Builder API failed",
+                None::<String>,
+            ));
+            // Builder should also return same payload ID for FCU
+            builder_mock.fcu_response = Ok(ForkchoiceUpdated::new(PayloadStatus::from_status(PayloadStatusEnum::Valid))
+                .with_payload_id(PayloadId::new([0, 0, 0, 0, 0, 0, 0, 1])));
+
+            let test_harness = TestHarness::new(Some(l2_mock), Some(builder_mock)).await;
+
+            // Send FCU with payload attributes to trigger builder request
+            let fcu = ForkchoiceState {
+                head_block_hash: FixedBytes::random(),
+                safe_block_hash: FixedBytes::random(),
+                finalized_block_hash: FixedBytes::random(),
+            };
+            let payload_attributes = OpPayloadAttributes {
+                gas_limit: Some(1000000),
+                ..Default::default()
+            };
+            let fcu_response = test_harness
+                .rpc_client
+                .fork_choice_updated_v3(fcu, Some(payload_attributes))
+                .await;
+            assert!(fcu_response.is_ok());
+
+            // Get payload should fail and mark builder as unhealthy
+            let payload_id = fcu_response.unwrap().payload_id.unwrap();
+            let get_payload_response = test_harness
+                .rpc_client
+                .get_payload_v3(payload_id)
+                .await;
+            assert!(get_payload_response.is_ok()); // Should fallback to L2
+
+            // Health should be PartialContent because builder API failed
+            let health = test_harness.get("healthz").await;
+            assert_eq!(health.status(), StatusCode::PARTIAL_CONTENT);
+
+            test_harness.cleanup().await;
+        }
+
+        // Test 2: L2 processing failure should NOT mark builder as unhealthy
+        {
+            let mut l2_mock = MockEngineServer::new();
+            // Ensure L2 returns a payload ID
+            l2_mock.fcu_response = Ok(ForkchoiceUpdated::new(PayloadStatus::from_status(PayloadStatusEnum::Valid))
+                .with_payload_id(PayloadId::new([0, 0, 0, 0, 0, 0, 0, 2])));
+            // Make L2 validation fail but builder API succeed
+            l2_mock.new_payload_response = Err(ErrorObject::owned(
+                INVALID_REQUEST_CODE,
+                "L2 validation failed",
+                None::<String>,
+            ));
+
+            let mut builder_mock = MockEngineServer::new();
+            // Builder should also return same payload ID for FCU
+            builder_mock.fcu_response = Ok(ForkchoiceUpdated::new(PayloadStatus::from_status(PayloadStatusEnum::Valid))
+                .with_payload_id(PayloadId::new([0, 0, 0, 0, 0, 0, 0, 2])));
+            // Builder API succeeds
+            builder_mock.get_payload_response = Ok(OpExecutionPayloadEnvelopeV3{
+                execution_payload: ExecutionPayloadV3 {
+                        payload_inner: ExecutionPayloadV2 {
+                            payload_inner: ExecutionPayloadV1 {
+                                base_fee_per_gas:  U256::from(7u64),
+                                block_number: 0xa946u64,
+                                block_hash: hex!("a5ddd3f286f429458a39cafc13ffe89295a7efa8eb363cf89a1a4887dbcf272b").into(),
+                                logs_bloom: hex!("00200004000000000000000080000000000200000000000000000000000000000000200000000000000000000000000000000000800000000200000000000000000000000000000000000008000000200000000000000000000001000000000000000000000000000000800000000000000000000100000000000030000000000000000040000000000000000000000000000000000800080080404000000000000008000000000008200000000000200000000000000000000000000000000000000002000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000100000000000000000000").into(),
+                                extra_data: hex!("d883010d03846765746888676f312e32312e31856c696e7578").into(),
+                                gas_limit: 0x1c9c380,
+                                gas_used: 0x1f4a9,
+                                timestamp: 0x651f35b8,
+                                fee_recipient: hex!("f97e180c050e5ab072211ad2c213eb5aee4df134").into(),
+                                parent_hash: hex!("d829192799c73ef28a7332313b3c03af1f2d5da2c36f8ecfafe7a83a3bfb8d1e").into(),
+                                prev_randao: hex!("753888cc4adfbeb9e24e01c84233f9d204f4a9e1273f0e29b43c4c148b2b8b7e").into(),
+                                receipts_root: hex!("4cbc48e87389399a0ea0b382b1c46962c4b8e398014bf0cc610f9c672bee3155").into(),
+                                state_root: hex!("017d7fa2b5adb480f5e05b2c95cb4186e12062eed893fc8822798eed134329d1").into(),
+                                transactions: vec![],
+                            },
+                            withdrawals: vec![],
+                        },
+                        blob_gas_used: 0xc0000,
+                    excess_blob_gas: 0x580000,
+                },
+                block_value: U256::from(15),
+                blobs_bundle: BlobsBundleV1{
+                    commitments: vec![],
+                    proofs: vec![],
+                    blobs: vec![],
+                },
+                should_override_builder: false,
+                parent_beacon_block_root: B256::ZERO,
+            });
+
+            let test_harness = TestHarness::new(Some(l2_mock), Some(builder_mock)).await;
+
+            // Send FCU with payload attributes to trigger builder request
+            let fcu = ForkchoiceState {
+                head_block_hash: FixedBytes::random(),
+                safe_block_hash: FixedBytes::random(),
+                finalized_block_hash: FixedBytes::random(),
+            };
+            let payload_attributes = OpPayloadAttributes {
+                gas_limit: Some(1000000),
+                ..Default::default()
+            };
+            let fcu_response = test_harness
+                .rpc_client
+                .fork_choice_updated_v3(fcu, Some(payload_attributes))
+                .await;
+            assert!(fcu_response.is_ok());
+
+            // Get payload - builder API succeeds but L2 processing fails
+            let payload_id = fcu_response.unwrap().payload_id.unwrap();
+            let get_payload_response = test_harness
+                .rpc_client
+                .get_payload_v3(payload_id)
+                .await;
+            assert!(get_payload_response.is_ok()); // Should fallback to L2
+
+            // Health should remain Healthy because builder API succeeded
+            // (L2 processing failure doesn't affect builder health)
+            let health = test_harness.get("healthz").await;
+            assert_eq!(health.status(), StatusCode::OK);
+
+            test_harness.cleanup().await;
+        }
+    }
 }

--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -179,8 +179,9 @@ impl RollupBoostServer {
         }
 
         // Forward the get payload request to the builder
-        // Returns (payload_option, builder_api_failed)  
-        let builder_fut: std::pin::Pin<Box<dyn std::future::Future<Output = Result<(Option<OpExecutionPayloadEnvelope>, bool), jsonrpsee::types::ErrorObject<'static>>> + Send>> = Box::pin(async {
+        // Returns (payload_option, builder_api_failed)
+        type BuilderResult = Result<(Option<OpExecutionPayloadEnvelope>, bool), ErrorObject<'static>>;
+        let builder_fut = async move {
             if let Some(cause) = self.payload_trace_context.trace_id(&payload_id).await {
                 tracing::Span::current().follows_from(cause);
             }
@@ -191,14 +192,14 @@ impl RollupBoostServer {
             {
                 info!(message = "builder has no payload, skipping get_payload call to builder");
                 tracing::Span::current().record("builder_has_payload", false);
-                return Ok((None, true));
+                return BuilderResult::Ok((None, true));
             }
 
             if !self.allow_traffic_to_unhealthy_builder
                 && !matches!(self.probes.health(), Health::Healthy)
             {
                 info!(message = "builder is unhealthy, skipping get_payload call to builder");
-                return Ok((None, true));
+                return BuilderResult::Ok((None, true));
             }
 
             // Get payload and validate with the local l2 client
@@ -210,7 +211,7 @@ impl RollupBoostServer {
                 Ok(payload) => payload,
                 Err(e) => {
                     error!(message = "builder get_payload API failed", error = %e);
-                    return Ok((None, true)); // Builder API failed
+                    return BuilderResult::Ok((None, true)); // Builder API failed
                 }
             };
 
@@ -220,10 +221,10 @@ impl RollupBoostServer {
                     .new_payload(NewPayload::from(payload.clone()))
                     .await
                 {
-                    Ok(_) => return Ok((Some(payload), false)),
+                    Ok(_) => return BuilderResult::Ok((Some(payload), false)),
                     Err(e) => {
                         error!(message = "L2 validation failed, but builder API succeeded", error = %e);
-                        return Ok((None, false)); // L2 processing failed, not builder API
+                        return BuilderResult::Ok((None, false)); // L2 processing failed, not builder API
                     }
                 }
             }
@@ -261,7 +262,7 @@ impl RollupBoostServer {
                 Ok(result) => result,
                 Err(e) => {
                     error!(message = "L2 FCU failed, failed to start state root calculation", error = %e);
-                    return Ok((None, false)); // L2 processing failed, not builder API
+                    return BuilderResult::Ok((None, false)); // L2 processing failed, not builder API
                 }
             };
 
@@ -279,18 +280,18 @@ impl RollupBoostServer {
                             message = "received new state root payload from l2",
                             payload = ?new_payload,
                         );
-                        return Ok((Some(new_payload), false));
+                        return BuilderResult::Ok((Some(new_payload), false));
                     }
 
                     Err(e) => {
                         error!(message = "error getting new state root payload from l2", error = %e);
-                        return Ok((None, false)); // L2 processing failed, not builder API
+                        return BuilderResult::Ok((None, false)); // L2 processing failed, not builder API
                     }
                 }
             }
 
-            Ok((None, false))
-        });
+            BuilderResult::Ok((None, false))
+        };
 
         let (builder_result, l2_payload) = tokio::join!(builder_fut, l2_fut);
 


### PR DESCRIPTION
Modified get_payload method in server.rs:
  - Restructured the builder_fut async block to return (Option<OpExecutionPayloadEnvelope>, bool) where the boolean indicates whether the builder API
  specifically failed
  - Wrapped builder.get_payload() in explicit error handling to distinguish API failures from processing failures
  - All L2 processing errors now return (None, false) indicating no builder API failure
  - Only set Health::PartialContent when builder_api_failed && !self.execution_mode().is_dry_run()

  Testing

  - Updated existing test: Fixed engine_success test expectation since builder was never asked to build (FCU without payload attributes)
  - Added comprehensive test: builder_api_failure_vs_processing_failure validates both scenarios:
    - Builder API failure correctly marks builder unhealthy
    - L2 processing failure keeps builder healthy