### PR TITLE
Remove unnecessary payload storing

### DIFF
--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -478,10 +478,6 @@ impl EngineApiServer for RollupBoostServer {
                             span.id(),
                         )
                         .await;
-
-                    self.payload_to_fcu_request
-                        .lock()
-                        .insert(payload_id, (fork_choice_state, payload_attributes));
                 }
 
                 // We always return the value from the l2 client


### PR DESCRIPTION
With FCU no_txpool, there's no point to store the payload to memory given the builder would not be called to start block building when the sequencer is just syncing.
Thus removing this unnecesasry payload storing