### PR TITLE
feat(websocket-proxy): add message send duration and queue size metrics

### DIFF
--- a/crates/websocket-proxy/src/metrics.rs
+++ b/crates/websocket-proxy/src/metrics.rs
@@ -9,7 +9,7 @@ pub struct Metrics {
     #[metric(describe = "Count of messages that were unable to be sent")]
     pub failed_messages: Counter,
 
-    #[metric(describe = "Duration of message send operations in seconds")]
+    #[metric(describe = "Duration of message send operations")]
     pub message_send_duration: Histogram,
 
     #[metric(describe = "Current size of the broadcast message queue")]

--- a/crates/websocket-proxy/src/metrics.rs
+++ b/crates/websocket-proxy/src/metrics.rs
@@ -1,4 +1,4 @@
-use metrics::{counter, Counter, Gauge};
+use metrics::{counter, Counter, Gauge, Histogram};
 use metrics_derive::Metrics;
 #[derive(Metrics)]
 #[metrics(scope = "websocket_proxy")]
@@ -8,6 +8,12 @@ pub struct Metrics {
 
     #[metric(describe = "Count of messages that were unable to be sent")]
     pub failed_messages: Counter,
+
+    #[metric(describe = "Duration of message send operations in seconds")]
+    pub message_send_duration: Histogram,
+
+    #[metric(describe = "Current size of the broadcast message queue")]
+    pub broadcast_queue_size: Gauge,
 
     #[metric(describe = "Count of new connections opened")]
     pub new_connections: Counter,

--- a/crates/websocket-proxy/src/registry.rs
+++ b/crates/websocket-proxy/src/registry.rs
@@ -64,7 +64,6 @@ impl Registry {
         loop {
             tokio::select! {
                 broadcast_result = receiver.recv() => {
-                    // Update gauge with current broadcast queue size
                     metrics.broadcast_queue_size.set(self.sender.len() as f64);
                     
                     match broadcast_result {
@@ -86,10 +85,9 @@ impl Registry {
                                     metrics.failed_messages.increment(1);
                                     break;
                                 }
-                                let send_duration = send_start.elapsed();
-                                metrics.message_send_duration.record(send_duration.as_secs_f64());
+                                metrics.message_send_duration.record(send_start.elapsed());
                                 
-                                trace!(message = "message sent to client", client = client_id, duration_ms = send_duration.as_millis());
+                                trace!(message = "message sent to client", client = client_id);
                                 metrics.sent_messages.increment(1);
                                 metrics.bytes_broadcasted.increment(get_message_size(&msg));
                             } else {


### PR DESCRIPTION
## Summary
Adds two new metrics to improve observability of the WebSocket proxy's message delivery performance and queue health.

## Changes
- **Message Send Duration Histogram** (`message_send_duration`): Tracks the time taken to send each message to clients, enabling detection of slow connections and network latency issues
- **Broadcast Queue Size Gauge** (`broadcast_queue_size`): Monitors the current depth of the broadcast channel queue, providing visibility into backpressure and consumer lag

## Metrics Added
- `websocket_proxy.message_send_duration` (histogram, seconds) - Duration of WebSocket send operations
- `websocket_proxy.broadcast_queue_size` (gauge) - Current number of messages queued in the broadcast channel