### PR TITLE
feat(websocket-proxy): add client timeout

### DIFF
--- a/crates/websocket-proxy/src/main.rs
+++ b/crates/websocket-proxy/src/main.rs
@@ -171,6 +171,14 @@ struct Args {
         help = "Timeout in milliseconds to wait for pong response from clients"
     )]
     client_pong_timeout_ms: u64,
+
+    #[arg(
+        long,
+        env,
+        default_value = "1000",
+        help = "Timeout in milliseconds for sending messages to clients"
+    )]
+    client_send_timeout_ms: u64,
 }
 
 #[tokio::main]
@@ -351,6 +359,7 @@ async fn main() {
         args.enable_compression,
         args.client_ping_enabled,
         args.client_pong_timeout_ms,
+        args.client_send_timeout_ms,
     );
 
     let rate_limiter = match &args.redis_url {

--- a/crates/websocket-proxy/src/main.rs
+++ b/crates/websocket-proxy/src/main.rs
@@ -359,7 +359,7 @@ async fn main() {
         args.enable_compression,
         args.client_ping_enabled,
         args.client_pong_timeout_ms,
-        args.client_send_timeout_ms,
+        Duration::from_millis(args.client_send_timeout_ms),
     );
 
     let rate_limiter = match &args.redis_url {

--- a/crates/websocket-proxy/src/registry.rs
+++ b/crates/websocket-proxy/src/registry.rs
@@ -27,6 +27,7 @@ pub struct Registry {
     compressed: bool,
     ping_enabled: bool,
     pong_timeout_ms: u64,
+    send_timeout_ms: u64,
 }
 
 impl Registry {
@@ -36,6 +37,7 @@ impl Registry {
         compressed: bool,
         ping_enabled: bool,
         pong_timeout_ms: u64,
+        send_timeout_ms: u64,
     ) -> Self {
         Self {
             sender,
@@ -43,6 +45,7 @@ impl Registry {
             compressed,
             ping_enabled,
             pong_timeout_ms,
+            send_timeout_ms,
         }
     }
 
@@ -74,7 +77,7 @@ impl Registry {
                                 trace!(message = "filter matched for client", client = client_id, filter = ?filter);
 
                                 let send_start = Instant::now();
-                                let send_timeout = Duration::from_secs(1);
+                                let send_timeout = Duration::from_millis(self.send_timeout_ms);
                                 let send_result = timeout(send_timeout, ws_sender.send(msg.clone())).await;
                                 let send_duration = send_start.elapsed();
                                 
@@ -102,7 +105,7 @@ impl Registry {
                                         warn!(
                                             message = "send timeout - disconnecting slow client",
                                             client = client_id,
-                                            timeout_secs = send_timeout.as_secs()
+                                            timeout_ms = send_timeout.as_millis()
                                         );
                                         metrics.failed_messages.increment(1);
                                         break;

--- a/crates/websocket-proxy/tests/integration.rs
+++ b/crates/websocket-proxy/tests/integration.rs
@@ -43,7 +43,14 @@ impl TestHarness {
     fn new_with_auth(addr: SocketAddr, auth: Option<Authentication>) -> TestHarness {
         let (sender, _) = broadcast::channel(5);
         let metrics = Arc::new(Metrics::default());
-        let registry = Registry::new(sender.clone(), metrics.clone(), false, false, 120000);
+        let registry = Registry::new(
+            sender.clone(),
+            metrics.clone(),
+            false,
+            false,
+            120000,
+            Duration::from_millis(1000),
+        );
         let rate_limited = Arc::new(InMemoryRateLimit::new(3, 10));
 
         Self {
@@ -379,7 +386,14 @@ async fn test_ping_timeout_disconnects_client() {
 
     let (sender, _) = broadcast::channel(5);
     let metrics = Arc::new(Metrics::default());
-    let registry = Registry::new(sender.clone(), metrics.clone(), false, true, 1000);
+    let registry = Registry::new(
+        sender.clone(),
+        metrics.clone(),
+        false,
+        true,
+        1000,
+        Duration::from_millis(1000),
+    );
     let rate_limited = Arc::new(InMemoryRateLimit::new(3, 10));
 
     let mut harness = TestHarness {


### PR DESCRIPTION
## Summary
Adds a configurable timeout for WebSocket send operations to prevent slow clients from blocking message delivery.

## Changes
- Added 1-second timeout wrapper around `ws_sender.send()` calls
- Environment variable: `CLIENT_SEND_TIMEOUT_MS`
- Slow clients exceeding timeout are automatically disconnected with warning log