### PR TITLE
Not mark unhealthy if missing payload

### DIFF
--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -198,7 +198,7 @@ where
                 tracing::Span::current().record("builder_has_payload", false);
                 return BuilderResult::Ok(BuilderPayloadResult {
                     payload: None,
-                    builder_api_failed: true,
+                    builder_api_failed: false,
                 });
             }
 
@@ -536,7 +536,7 @@ where
             // forward the fcu to the builder to keep it synced and immediately return the l2
             // response without awaiting the builder
             let builder_client = self.builder_client.clone();
-            let attrs_clone = payload_attributes.clone();
+            let attrs_clone: Option<OpPayloadAttributes> = payload_attributes.clone();
             tokio::spawn(async move {
                 // It is not critical to wait for the builder response here
                 // During moments of high load, Op-node can send hundreds of FCU requests

--- a/crates/rollup-boost/src/server.rs
+++ b/crates/rollup-boost/src/server.rs
@@ -536,7 +536,7 @@ where
             // forward the fcu to the builder to keep it synced and immediately return the l2
             // response without awaiting the builder
             let builder_client = self.builder_client.clone();
-            let attrs_clone: Option<OpPayloadAttributes> = payload_attributes.clone();
+            let attrs_clone = payload_attributes.clone();
             tokio::spawn(async move {
                 // It is not critical to wait for the builder response here
                 // During moments of high load, Op-node can send hundreds of FCU requests


### PR DESCRIPTION
Marking it as unhealthy when missing payload can cause a vicious cycle that

Builder temporarily missing payload -> marked as unhealthy -> not sending FCU to the builder -> builder marked as healthy -> but missing payload due to no FCU -> marked as unhealthy again despite at the tip

Not marking as unhealthy allows some tolerance on temporary failures, to prevent the vicious cycle.