### PR TITLE
feat: add delay to broadcast flashblock messages

### DIFF
--- a/crates/websocket-proxy/src/main.rs
+++ b/crates/websocket-proxy/src/main.rs
@@ -179,6 +179,14 @@ struct Args {
         help = "Timeout in milliseconds for sending messages to clients"
     )]
     client_send_timeout_ms: u64,
+
+    #[arg(
+        long,
+        env,
+        default_value = "0",
+        help = "Delay in milliseconds before broadcasting received messages to clients"
+    )]
+    listener_delay_ms: u64,
 }
 
 #[tokio::main]
@@ -301,7 +309,8 @@ async fn main() {
             .with_ping_interval(Duration::from_millis(args.subscriber_ping_interval_ms))
             .with_pong_timeout(Duration::from_millis(args.subscriber_pong_timeout_ms))
             .with_backoff_initial_interval(Duration::from_millis(500))
-            .with_initial_grace_period(Duration::from_secs(5));
+            .with_initial_grace_period(Duration::from_secs(5))
+            .with_listener_delay(Duration::from_millis(args.listener_delay_ms));
 
         let mut subscriber =
             WebsocketSubscriber::new(uri_clone.clone(), listener_clone, metrics_clone, options);

--- a/crates/websocket-proxy/src/subscriber.rs
+++ b/crates/websocket-proxy/src/subscriber.rs
@@ -20,6 +20,7 @@ pub struct SubscriberOptions {
     pub ping_interval: Duration,
     pub pong_timeout: Duration,
     pub initial_grace_period: Duration,
+    pub listener_delay: Duration,
 }
 
 impl SubscriberOptions {
@@ -47,6 +48,11 @@ impl SubscriberOptions {
         self.initial_grace_period = initial_grace_period;
         self
     }
+
+    pub fn with_listener_delay(mut self, listener_delay: Duration) -> Self {
+        self.listener_delay = listener_delay;
+        self
+    }
 }
 
 impl Default for SubscriberOptions {
@@ -57,6 +63,7 @@ impl Default for SubscriberOptions {
             ping_interval: Duration::from_secs(1),
             pong_timeout: Duration::from_secs(2),
             initial_grace_period: Duration::from_secs(5),
+            listener_delay: Duration::ZERO,
         }
     }
 }
@@ -258,6 +265,9 @@ where
                 );
                 self.metrics
                     .message_received_from_upstream(self.uri.to_string().as_str());
+                if !self.options.listener_delay.is_zero() {
+                    tokio::time::sleep(self.options.listener_delay).await;
+                }
                 (self.handler)(text.to_string());
             }
             Message::Binary(data) => {


### PR DESCRIPTION
Adding a flag to add delay when sending out flashblock messages to downstream clients